### PR TITLE
[145] data loading pali

### DIFF
--- a/dataloader/utils.py
+++ b/dataloader/utils.py
@@ -55,7 +55,7 @@ def should_download_file(file_lang: str, file_name: str) -> bool:
     Limit source file set size to speed up loading process
     Can be controlled with the `LIMIT` environment variable.
     """
-    if file_lang == LANG_PALI and file_name.startswith("MN"):
+    if file_lang == LANG_PALI and file_name.startswith("dn"):
         return True
     elif file_lang == LANG_CHINESE and file_name.startswith("T31"):
         return True


### PR DESCRIPTION
The pali files did not load due to the wrong acronym. It said 'MN', which does not exist. It should be lowercase 'mn' or I made it 'dn' now because that is a much smaller collection so faster loading time for testing.